### PR TITLE
Update require-dbt-version to allow for 0.19

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'cc_dbt_utils'
 version: '0.1.0'
 
-require-dbt-version: [">=0.18.0", "<0.19.0"]
+require-dbt-version: [">=0.18.0", "<=0.19.0"]
 config-version: 2
 
 target-path: "target"


### PR DESCRIPTION
Interesting, this looks like Fishtown's PR template? Anyway, updating to include 0.19 in our utils fork


This is a:
- [ ] bug fix PR with no breaking changes (please change the base branch to `main`)
- [ ] new functionality
- [ ] a breaking change

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to the changelog
