### PR TITLE
adding query to the end of the compare objects macro

### DIFF
--- a/macros/operations/compare_objects.sql
+++ b/macros/operations/compare_objects.sql
@@ -235,8 +235,15 @@ dbt run-operation compare_objects --args "{comparison_schema: dbt_kevin, object_
   	{%- endfor -%}
 
 	{% do log('seems like we finished!', True) %}
-    {% do log('check the dbt_model_comparison_results table in your comparison schema for the results, should be listed under invocation_id {0}'.format(invocation_id_value.rows[0][0]), True) %}
+    {% do log('check the dbt_model_comparison_results table in your comparison schema for the results, should be listed under invocation_id {0}:'.format(invocation_id_value.rows[0][0]), True) %}
+    {% set query_string %}
+        
+    select *
+    from {{target.database}}.{{target.schema}}.dbt_model_comparison_results
+    where invocation_id = '{{ invocation_id_value.rows[0][0] }}'
 
+    {% endset %}
+    {% do log('{0}'.format(query_string), True) %}
     
 {% endmacro %}
 


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes (please change the base branch to `main`)
- [x] new functionality
- [ ] a breaking change

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Adding in logic to print the query that needs to be run to get the compare objects output in snowflake

## Checklist
- [x] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [x] Snowflake
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to the changelog
