### PR TITLE
add invocation and warehouse

### DIFF
--- a/macros/hooks/get_run_audit.sql
+++ b/macros/hooks/get_run_audit.sql
@@ -41,12 +41,15 @@ This macro gets back a dictionary like:
         {% set model_result={} %}
         -- Get the materelizaed type of our model, View, Incremental etc.
         {% set materialization=config.get("materialized")%}
-
+        {% set warehouse=config.get("snowflake_warehouse")%}
+        
         {% do model_result.update({'name': result.node.name}) %}
         {% do model_result.update({'package': result.node.package_name}) %}
         -- Schema the model belongs to
         {% do model_result.update({'schema': result.node.schema}) %}
         {% do model_result.update({'materialized': materialization}) %}
+        {% do model_result.update({'warehouse': warehouse}) %}
+        {% do model_result.update({'invocation_id': invocation_id}) %}
 
         {% for timing in result.timing %}
             {% if timing['name'] == 'execute' %}


### PR DESCRIPTION
This is a:
- [ ] bug fix PR with no breaking changes — please ensure the base branch is `master`
- [x] new functionality — please ensure the base branch is the latest `dev/` branch
- [ ] a breaking change — please ensure the base branch is the latest `dev/` branch

## Description & motivation
Add invocation id and warehouse. I wasn't able to test warehouse locally (everything came back as None), but I'll see what comes back from production tomorrow.

## Checklist
- [ ] I have verified that these changes work locally on the following warehouses (Note: it's okay if you do not have access to all warehouses, this helps us understand what has been covered)
    - [ ] BigQuery
    - [ ] Postgres
    - [ ] Redshift
    - [ ] Snowflake
- [ ] I followed guidelines to ensure that my changes will work on "non-core" adapters by:
    - [ ] dispatching any new macro(s) so non-core adapters can also use them (e.g. [the `star()` source](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/star.sql))
    - [ ] using the `limit_zero()` macro in place of the literal string: `limit 0`
    - [ ] using `dbt_utils.type_*` macros instead of explicit datatypes (e.g. `dbt_utils.type_timestamp()` instead of `TIMESTAMP`
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have added an entry to CHANGELOG.md
